### PR TITLE
Software Design; Gorbunov; Task 3

### DIFF
--- a/common/src/main/java/au/sdshell/common/FileResolver.java
+++ b/common/src/main/java/au/sdshell/common/FileResolver.java
@@ -2,6 +2,7 @@ package au.sdshell.common;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedList;

--- a/driver/src/main/java/au/sdshell/driver/Driver.java
+++ b/driver/src/main/java/au/sdshell/driver/Driver.java
@@ -2,6 +2,7 @@ package au.sdshell.driver;
 
 import au.sdshell.common.Environment;
 import au.sdshell.driver.command.AssignCommand;
+import au.sdshell.driver.command.CDCommand;
 import au.sdshell.driver.command.ExitCommand;
 import au.sdshell.driver.command.ToolCommand;
 import javafx.util.Pair;
@@ -82,6 +83,8 @@ public class Driver {
             ((ExitCommand) c).run();
         } else if (c instanceof AssignCommand) {
             ((AssignCommand) c).run();
+        } else if (c instanceof CDCommand) {
+            ((CDCommand) c).run();
         } else {
             runToolCommand((ToolCommand) c);
         }

--- a/driver/src/main/java/au/sdshell/driver/InputParser.java
+++ b/driver/src/main/java/au/sdshell/driver/InputParser.java
@@ -2,6 +2,7 @@ package au.sdshell.driver;
 
 import au.sdshell.common.Environment;
 import au.sdshell.driver.command.AssignCommand;
+import au.sdshell.driver.command.CDCommand;
 import au.sdshell.driver.command.ExitCommand;
 import au.sdshell.driver.command.ToolCommand;
 import edu.rice.cs.util.ArgumentTokenizer;
@@ -63,7 +64,13 @@ public class InputParser {
         }
 
         if (command != null) {
-            commands.add(new ToolCommand(command, currentArgs));
+            if (command.equals("cd")) {
+                commands.add(new CDCommand(
+                        currentArgs.isEmpty() ? "" : currentArgs.getFirst()
+                ));
+            } else {
+                commands.add(new ToolCommand(command, currentArgs));
+            }
         }
         return commands;
     }

--- a/driver/src/main/java/au/sdshell/driver/command/CDCommand.java
+++ b/driver/src/main/java/au/sdshell/driver/command/CDCommand.java
@@ -1,0 +1,33 @@
+package au.sdshell.driver.command;
+
+import au.sdshell.common.Environment;
+import au.sdshell.common.FileResolver;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Created by: Egor Gorbunov
+ * Date: 12/8/16
+ * Email: egor-mailbox@ya.com
+ */
+
+public class CDCommand {
+    private final String distUserDir;
+
+    public CDCommand(String distUserDir) {
+        this.distUserDir = distUserDir;
+    }
+
+    public void run() {
+        String newDistDir = Environment.substituteVariables(distUserDir);
+        Environment env = Environment.getInstance();
+
+        Path newPWD = env.getCurrentDir().resolve(newDistDir).normalize();
+        if (!Files.exists(newPWD) || !Files.isDirectory(newPWD)) {
+            System.out.println("No such directory");
+        } else {
+            env.setCurrentDir(newPWD);
+        }
+    }
+}

--- a/driver/src/main/java/au/sdshell/driver/command/CDCommand.java
+++ b/driver/src/main/java/au/sdshell/driver/command/CDCommand.java
@@ -7,11 +7,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * Created by: Egor Gorbunov
- * Date: 12/8/16
- * Email: egor-mailbox@ya.com
+ * Shell command, which changes current working directory, which is passed
+ * as first argument
  */
-
 public class CDCommand {
     private final String distUserDir;
 
@@ -22,7 +20,6 @@ public class CDCommand {
     public void run() {
         String newDistDir = Environment.substituteVariables(distUserDir);
         Environment env = Environment.getInstance();
-
         Path newPWD = env.getCurrentDir().resolve(newDistDir).normalize();
         if (!Files.exists(newPWD) || !Files.isDirectory(newPWD)) {
             System.out.println("No such directory");

--- a/ls/build.gradle
+++ b/ls/build.gradle
@@ -1,0 +1,25 @@
+apply plugin: 'maven-publish'
+version '1.0'
+mainClassName = "au.sdshell.tools.ls.LSTool"
+
+repositories {
+    mavenCentral()
+}
+
+task fatJar(type: Jar) {
+    manifest {
+        attributes 'Implementation-Version': version,
+                'Main-Class': mainClassName
+    }
+    baseName = project.name + "-all"
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+}
+
+task sourceJar(type: Jar, dependsOn: classes) {
+    from sourceSets.main.output
+}
+
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '4.11'
+}

--- a/ls/src/main/java/au/sdshell/tools/ls/LSTool.java
+++ b/ls/src/main/java/au/sdshell/tools/ls/LSTool.java
@@ -6,29 +6,56 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Created by: Egor Gorbunov
- * Date: 12/8/16
- * Email: egor-mailbox@ya.com
+ * Shell command, which is used to list directory contents.
+ * If no arguments specified it lists working directory, otherwise it
+ * lists sequentially all directories passed as arguments
  */
 public class LSTool {
-    /**
-     * Prints contents of directory stored in PWD env. var;
-     */
     public static void main(String[] args) {
         Path pwd = Paths.get(Environment.getInstance().getVariable("PWD"));
+
+        List<Path> directoriesToList = new ArrayList<>();
+
+        if (args.length == 0) {
+            directoriesToList.add(pwd);
+        }
+
+        for (String arg : args) {
+            Path dir = pwd.resolve(arg);
+            if (!Files.exists(dir)) {
+                System.err.println("Directory not found: " + dir);
+                continue;
+            }
+
+            if (!Files.isDirectory(dir)) {
+                System.err.println("Not directory: " + arg);
+                continue;
+            }
+            directoriesToList.add(dir);
+        }
+
         try {
-            Files.list(pwd).forEach((p) -> {
-                if (Files.isDirectory(p)) {
-                    System.out.print("d ");
-                } else {
-                    System.out.print("f ");
+            for (Path dir : directoriesToList) {
+                if (directoriesToList.size() != 1) {
+                    System.out.println(pwd.relativize(dir) + ":");
                 }
-                System.out.println(pwd.relativize(p).normalize());
-            });
+                Files.list(dir).forEach((p) -> {
+                    if (Files.isDirectory(p)) {
+                        System.out.print("d ");
+                    } else {
+                        System.out.print("f ");
+                    }
+                    System.out.println(dir.relativize(p).normalize());
+                });
+            }
         } catch (IOException e) {
             System.err.println("Error reading directory contents: " + e.getMessage());
         }
     }
+
+
 }

--- a/ls/src/main/java/au/sdshell/tools/ls/LSTool.java
+++ b/ls/src/main/java/au/sdshell/tools/ls/LSTool.java
@@ -1,0 +1,34 @@
+package au.sdshell.tools.ls;
+
+import au.sdshell.common.Environment;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Created by: Egor Gorbunov
+ * Date: 12/8/16
+ * Email: egor-mailbox@ya.com
+ */
+public class LSTool {
+    /**
+     * Prints contents of directory stored in PWD env. var;
+     */
+    public static void main(String[] args) {
+        Path pwd = Paths.get(Environment.getInstance().getVariable("PWD"));
+        try {
+            Files.list(pwd).forEach((p) -> {
+                if (Files.isDirectory(p)) {
+                    System.out.print("d ");
+                } else {
+                    System.out.print("f ");
+                }
+                System.out.println(pwd.relativize(p).normalize());
+            });
+        } catch (IOException e) {
+            System.err.println("Error reading directory contents: " + e.getMessage());
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include ':pwd'
 include ':common'
 include 'wc'
 include 'grep'
+include 'ls'
 


### PR DESCRIPTION
Here we go.

Dear Andy. Thank you for such a great and useful project, however I've decided that two more commands (`ls` and `cd`) are unavoidable in any great command shell like yours.

What I like about your architecture:

* Separate subprojects for every command, which makes "builtin" commands equal to external commands. So the only thing I've done to add `ls` was adding new subproject

What I think is not so cool:

* Commands, which modify CLI context somehow are handled differently (I mean usual commands like exit, not assign) and this difference is even appears in the parser. I agree that this commands need a special treatment, but parser can be unified for them all. Because of this I had to change parser to handle `cd` command (however, another way was to unpack `ToolCommand` later outside parser, but that is not so cool too). I think that the better way is to decide which command is `ToolCommand` and which is not later, after parsing.